### PR TITLE
fix: update editor tabIndex when prop changes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -281,6 +281,10 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
       editor.setContents(delta);
       postpone(() => this.setEditorSelection(editor, selection));
     }
+
+    if (this.editor && this.props.tabIndex !== prevProps.tabIndex) {
+      this.setEditorTabIndex(this.editor, this.props.tabIndex);
+    }
   }
 
   instantiateEditor(): void {
@@ -402,9 +406,13 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     }
   }
 
-  setEditorTabIndex(editor: Quill, tabIndex: number) {
-    if (editor?.scroll?.domNode) {
-      (editor.scroll.domNode as HTMLElement).tabIndex = tabIndex;
+  setEditorTabIndex(editor: Quill, tabIndex?: number) {
+    const node = editor?.scroll?.domNode as HTMLElement | undefined;
+    if (!node) return;
+    if (tabIndex != null) {
+      node.tabIndex = tabIndex;
+    } else {
+      node.removeAttribute('tabindex');
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,7 @@ const { Quill } = require('../lib/index');
 const {
   mountReactQuill,
   getQuillInstance,
+  getQuillDOMNode,
   getQuillContentsAsHTML,
   setQuillContentsFromHTML,
   withMockedConsole,
@@ -183,6 +184,13 @@ describe('<ReactQuill />', function() {
     const wrapper = mountReactQuill({}, editingArea);
     const quill = getQuillInstance(wrapper);
     expect(wrapper.getDOMNode().querySelector('div#venus')).not.to.be.null;
+  });
+
+  it('updates tabIndex on the editor when the prop changes', () => {
+    const wrapper = mountReactQuill({ tabIndex: 3 });
+    expect(getQuillDOMNode(wrapper).tabIndex).to.equal(3);
+    wrapper.setProps({ tabIndex: 5 });
+    expect(getQuillDOMNode(wrapper).tabIndex).to.equal(5);
   });
 
   /**


### PR DESCRIPTION
## Summary
- ensure ReactQuill reapplies tabIndex to the underlying editor when the `tabIndex` prop changes
- allow removing a tabIndex by clearing the attribute
- add unit test for tabIndex updates

## Testing
- `npm run test:unit`
- `npm run test:coverage`
- `npm run test:browser` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1b57ea2c832d84aa941009b268d2